### PR TITLE
fix usage description of metadata command

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Usage:
   noscl setprivate <key>
   noscl public
   noscl publish [--reference=<id>...] [--profile=<id>...] <content>
-  noscl metadata --name=<name> [--description=<description>] [--image=<image>]
+  noscl metadata --name=<name> [--about=<about>] [--picture=<picture>]
   noscl profile <key>
   noscl follow <key> [--name=<name>]
   noscl unfollow <key>

--- a/main.go
+++ b/main.go
@@ -20,7 +20,7 @@ Usage:
   noscl verify <event-json>
   noscl public
   noscl publish [--reference=<id>...] [--profile=<id>...] <content>
-  noscl metadata --name=<name> [--description=<description>] [--image=<image>]
+  noscl metadata --name=<name> [--about=<about>] [--picture=<picture>]
   noscl profile <key>
   noscl follow <key> [--name=<name>]
   noscl unfollow <key>


### PR DESCRIPTION
The `noscl metadata` command had the wrong flags in the usage description. Changed it so it can be used correctly now. 