### PR TITLE
sending encrypted direct messages (nip04) with noscl

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Usage:
   noscl setprivate <key>
   noscl public
   noscl publish [--reference=<id>...] [--profile=<id>...] <content>
+  noscl message [--reference=<id>...] <id> <content>
   noscl metadata --name=<name> [--about=<about>] [--picture=<picture>]
   noscl profile <key>
   noscl follow <key> [--name=<name>]

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/btcsuite/btcd v0.20.1-beta
 	github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815
 	github.com/dustin/go-humanize v1.0.0
-	github.com/fiatjaf/go-nostr v0.5.0
+	github.com/fiatjaf/go-nostr v0.5.1
 	github.com/mitchellh/go-homedir v1.1.0
 	gopkg.in/yaml.v2 v2.2.2
 )

--- a/go.sum
+++ b/go.sum
@@ -29,8 +29,8 @@ github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/fiatjaf/bip340 v1.1.1 h1:qyVlP/uqt2bAWnJv8IPbKvC57645RosjnXKDH2SVJHQ=
 github.com/fiatjaf/bip340 v1.1.1/go.mod h1:MxAz+5FQUTW4OT2gnCBC6Our486wmqf72ykZIrh7+is=
-github.com/fiatjaf/go-nostr v0.5.0 h1:xyp5mgjQrmVz+F45rLTvccnOmW2RzuvDVLP2/QFH4r0=
-github.com/fiatjaf/go-nostr v0.5.0/go.mod h1:2mP07RTejqjchmXW+aF8eqJoa3wkHIVlmdDDXvL2p4U=
+github.com/fiatjaf/go-nostr v0.5.1 h1:SQfcJ4VCxkKdlvz/CN6G6y111DeUo1hcLZOqsIjje2A=
+github.com/fiatjaf/go-nostr v0.5.1/go.mod h1:2mP07RTejqjchmXW+aF8eqJoa3wkHIVlmdDDXvL2p4U=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=

--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ Usage:
   noscl verify <event-json>
   noscl public
   noscl publish [--reference=<id>...] [--profile=<id>...] <content>
+  noscl message [--reference=<id>...] <id> <content>
   noscl metadata --name=<name> [--about=<about>] [--picture=<picture>]
   noscl profile <key>
   noscl follow <key> [--name=<name>]
@@ -80,6 +81,8 @@ func main() {
 		showPublicKey(opts)
 	case opts["publish"].(bool):
 		publish(opts)
+	case opts["message"].(bool):
+		message(opts)
 	case opts["share-contacts"].(bool):
 		shareContacts(opts)
 	case opts["key-gen"].(bool):

--- a/message.go
+++ b/message.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"log"
+	"time"
+
+	"github.com/docopt/docopt-go"
+	"github.com/fiatjaf/go-nostr"
+	"github.com/fiatjaf/go-nostr/nip04"
+)
+
+func message(opts docopt.Opts) {
+	if config.PrivateKey == "" {
+		log.Printf("Can't direct message. Private key not set.\n")
+		return
+	}
+
+	initNostr()
+
+	tags := []nostr.Tag{}
+	receiverID := opts["<id>"].(string)
+	tags = append(tags, nostr.Tag([]interface{}{"p", receiverID}))
+
+	references, err := optSlice(opts, "--reference")
+	if err != nil {
+		return
+	}
+	for _, ref := range references {
+		tags = append(tags, nostr.Tag([]interface{}{"e", ref}))
+	}
+
+	// parse and encrypt content
+	message := opts["<content>"].(string)
+	sharedSecret, err := nip04.ComputeSharedSecret(config.PrivateKey, receiverID)
+	if err != nil {
+		log.Printf("Error computing shared key: %s. \n", err.Error())
+		return
+	}
+
+	encryptedMessage, err := nip04.Encrypt(message, sharedSecret)
+	if err != nil {
+		log.Printf("Error encrypting message: %s. \n", err.Error())
+		return
+	}
+
+	event, statuses, err := pool.PublishEvent(&nostr.Event{
+		CreatedAt: uint32(time.Now().Unix()),
+		Kind:      nostr.KindEncryptedDirectMessage,
+		Tags:      tags,
+		Content:   encryptedMessage,
+	})
+	if err != nil {
+		log.Printf("Error messaging: %s.\n", err.Error())
+		return
+	}
+
+	printPublishStatus(event, statuses)
+}


### PR DESCRIPTION
Wanted to send a direct message with `noscl` and noticed that this was not supported. I have an open PR in the upstream `go-nostr` module/library that implements the basic nip04 functions (shared key generation, encryption, decryption). This PR can't be merged until the upstream merges and releases a new version. 

I have no idea if this is the best way to do this, so just let me know if this is the wrong approach. 