### PR TITLE
feat: add verbose flag to display full ids and pubkeys

### DIFF
--- a/event.go
+++ b/event.go
@@ -8,6 +8,7 @@ import (
 )
 
 func view(opts docopt.Opts) {
+	verbose, _ := opts.Bool("--verbose")
 	id := opts["<id>"].(string)
 	if id == "" {
 		log.Println("provided event ID was empty")
@@ -23,7 +24,7 @@ func view(opts docopt.Opts) {
 			continue
 		}
 
-		printEvent(event, nil)
+		printEvent(event, nil, verbose)
 		break
 	}
 }

--- a/home.go
+++ b/home.go
@@ -16,6 +16,8 @@ func home(opts docopt.Opts) {
 
 	initNostr()
 
+	verbose, _ := opts.Bool("--verbose")
+
 	var keys []string
 
 	nameMap := map[string]string{}
@@ -55,6 +57,6 @@ func home(opts docopt.Opts) {
 			}
 		}
 
-		printEvent(event, &nick)
+		printEvent(event, &nick, verbose)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ import (
 const USAGE = `noscl
 
 Usage:
-  noscl home
+  noscl home [--verbose]
   noscl setprivate <key>
   noscl sign <event-json>
   noscl verify <event-json>
@@ -22,10 +22,10 @@ Usage:
   noscl publish [--reference=<id>...] [--profile=<id>...] <content>
   noscl message [--reference=<id>...] <pubkey> <content>
   noscl metadata --name=<name> [--about=<about>] [--picture=<picture>]
-  noscl profile <pubkey>
+  noscl profile [--verbose] <pubkey>
   noscl follow <pubkey> [--name=<name>]
   noscl unfollow <pubkey>
-  noscl event <id>
+  noscl event [--verbose] <id>
   noscl share-contacts
   noscl key-gen
   noscl relay

--- a/printer.go
+++ b/printer.go
@@ -19,7 +19,7 @@ var kindNames = map[int]string{
 	nostr.KindDeletion:               "Deletion Notice",
 }
 
-func printEvent(evt nostr.Event, nick *string) {
+func printEvent(evt nostr.Event, nick *string, verbose bool) {
 	kind, ok := kindNames[evt.Kind]
 	if !ok {
 		kind = "Unknown Kind"
@@ -32,17 +32,26 @@ func printEvent(evt nostr.Event, nick *string) {
 		}
 	}
 
-	var fromField string
+	var ID string = shorten(evt.ID)
+	var fromField string = shorten(evt.PubKey)
 
-	if nick == nil {
-		fromField = shorten(evt.PubKey)
-	} else {
+	if nick != nil {
 		fromField = fmt.Sprintf("%s (%s)", *nick, shorten(evt.PubKey))
+	}
+
+	if verbose {
+		ID = evt.ID
+
+		if nick == nil {
+			fromField = evt.PubKey
+		} else {
+			fromField = fmt.Sprintf("%s (%s)", *nick, evt.PubKey)
+		}
 	}
 
 	fmt.Printf("%s [%s] from %s %s\n  ",
 		kind,
-		shorten(evt.ID),
+		ID,
 		fromField,
 		humanize.Time(evt.CreatedAt),
 	)

--- a/profile.go
+++ b/profile.go
@@ -11,6 +11,7 @@ import (
 func showProfile(opts docopt.Opts) {
 	initNostr()
 
+	verbose, _ := opts.Bool("--verbose")
 	key := opts["<pubkey>"].(string)
 	if key == "" {
 		log.Println("Profile key is empty! Exiting.")
@@ -19,7 +20,7 @@ func showProfile(opts docopt.Opts) {
 
 	sub := pool.Sub(nostr.Filters{{Authors: []string{key}}})
 	for event := range sub.UniqueEvents {
-		printEvent(event, nil)
+		printEvent(event, nil, verbose)
 	}
 }
 


### PR DESCRIPTION
This PR adds a `--verbose` flag to relevant commands (`home`, `event` and `profile`), that can be used to display the entirety of the events ids and profiles pubkeys instead of shorten strings. 

This felt needed, as there are tools to get the full event or profile data (e.g. https://nostr.com/), but `noscl` only displays by default shorten strings (the only moment they aren't shorten is when a new event is sent).

If the name `verbose` is not suitable, we can definitely find a better one.