### PR TITLE
publish,message: accept content from stdin

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
+	"io"
 	"log"
 	"os"
 )
@@ -17,4 +19,17 @@ func saveConfig(path string) {
 	enc.SetIndent("", "  ")
 
 	enc.Encode(config)
+}
+
+// readContentStdin reads from stdin until EOF or up to max + 1 bytes.
+// it return an error if the read length is larger than max.
+func readContentStdin(max int) (string, error) {
+	b, err := io.ReadAll(io.LimitReader(os.Stdin, int64(max)+1))
+	if err != nil {
+		return "", err
+	}
+	if len(b) == max+1 {
+		return "", fmt.Errorf("too big; want max %d bytes", max)
+	}
+	return string(b), nil
 }

--- a/main.go
+++ b/main.go
@@ -33,6 +33,9 @@ Usage:
   noscl relay add <url>
   noscl relay remove <url>
   noscl relay recommend <url>
+
+Specify <content> as '-' to make the publish or message command read it
+from stdin.
 `
 
 func main() {

--- a/message.go
+++ b/message.go
@@ -31,6 +31,12 @@ func message(opts docopt.Opts) {
 
 	// parse and encrypt content
 	message := opts["<content>"].(string)
+	if message == "-" {
+		message, err = readContentStdin(4096)
+		if err != nil {
+			log.Printf("Failed reading content from stdin: %s", err)
+		}
+	}
 	sharedSecret, err := nip04.ComputeSharedSecret(config.PrivateKey, receiverKey)
 	if err != nil {
 		log.Printf("Error computing shared key: %s. \n", err.Error())

--- a/publish.go
+++ b/publish.go
@@ -39,11 +39,18 @@ func publish(opts docopt.Opts) {
 		tags = append(tags, nostr.StringList{"p", profile})
 	}
 
+	content := opts["<content>"].(string)
+	if content == "-" {
+		content, err = readContentStdin(4096)
+		if err != nil {
+			log.Printf("Failed reading content from stdin: %s", err)
+		}
+	}
 	event, statuses, err := pool.PublishEvent(&nostr.Event{
 		CreatedAt: time.Now(),
 		Kind:      nostr.KindTextNote,
 		Tags:      tags,
-		Content:   opts["<content>"].(string),
+		Content:   content,
 	})
 	if err != nil {
 		log.Printf("Error publishing: %s.\n", err.Error())


### PR DESCRIPTION
if the <content> arg to publish or message command is '-', it is read from stdin.

closes https://github.com/fiatjaf/noscl/issues/19