### PR TITLE
go.mod: undo accidental local replacement directive

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,5 +28,3 @@ require (
 	golang.org/x/exp v0.0.0-20221106115401-f9659909a136 // indirect
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 )
-
-replace github.com/nbd-wtf/go-nostr => /home/fiatjaf/comp/go-nostr


### PR DESCRIPTION
the project fails to compile at 570241b due to:

    replacement directory /home/fiatjaf/comp/go-nostr does not exist