### PR TITLE
main: pass docopt only the remaining command line args

### DIFF
--- a/main.go
+++ b/main.go
@@ -65,7 +65,7 @@ func main() {
 	config.Init()
 
 	// parse args
-	opts, err := docopt.ParseDoc(USAGE)
+	opts, err := docopt.ParseArgs(USAGE, flag.Args(), "")
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
the original intention was that -datadir flag is parsed by the stdlib's flag pkg and the remaining args by docopt.

however, docopt.ParseDoc parses again all cmd line flags passed to noscl executable. since -datadir isn't defined for docopt, the following invocation is invalid:

    noscl -datadir path/to/dir <sub-command>

this commit passes docopt only the args left after stdlib's flag parsing so the above example now works.