### PR TITLE
feat: relay remove --all

### DIFF
--- a/main.go
+++ b/main.go
@@ -31,6 +31,7 @@ Usage:
   noscl key-gen
   noscl relay
   noscl relay add <url>
+  noscl relay remove [--all]
   noscl relay remove <url>
   noscl relay recommend <url>
 

--- a/relay.go
+++ b/relay.go
@@ -16,9 +16,15 @@ func addRelay(opts docopt.Opts) {
 }
 
 func removeRelay(opts docopt.Opts) {
-	addr := opts["<url>"].(string)
-	delete(config.Relays, addr)
-	fmt.Printf("Removed relay %s.\n", addr)
+	if addr, _ := opts.String("<url>"); addr != "" {
+		delete(config.Relays, addr)
+		fmt.Printf("Removed relay %s.\n", addr)
+	}
+
+	if all, _ := opts.Bool("--all"); all {
+		config.Relays = map[string]Policy{}
+		fmt.Println("Removed all relays.")
+	}
 }
 
 func recommendRelay(opts docopt.Opts) {


### PR DESCRIPTION
Adds an --all flag to delete all relays

```
$ noscl relay
wss://1.example.com: rw
wss://2.example.com: rw
wss://3.example.com: rw
wss://4.example.com: rw
wss://5.example.com: rw

$ noscl relay remove wss://1.example.com
Removed relay wss://1.example.com.

$ noscl relay
wss://2.example.com: rw
wss://3.example.com: rw
wss://4.example.com: rw
wss://5.example.com: rw

$ noscl relay remove --all
Removed all relays.

$ noscl relay
```