### PR TITLE
feat(sign): Include event.ID in output

### DIFF
--- a/sign-verify.go
+++ b/sign-verify.go
@@ -32,7 +32,7 @@ func signEventJSON(opts docopt.Opts) {
 		return
 	}
 
-	fmt.Printf("Signature:\n  %s\n", event.Sig)
+	fmt.Printf("Id: %s\nSignature: %s\n", event.ID, event.Sig)
 }
 
 func verifyEventJSON(opts docopt.Opts) {


### PR DESCRIPTION
ID is calculated at the same time as the signature. Include both in the output. 

Example usage:
```diff
noscl sign $(cat event.json)
- Signature:
-  - 22265ee70850324c45ce49a0599d86583a0b5bed82e4074fdc93f7d7fb8a1142f14783eb846be48a6d688988a4e203919ec0ccd3658fe742931a2f0ceaca728e
+ Id: 5065600f21bc5a1a0af492eb30aac9c9ad47c3df2a9bee0fc822eb3190dfda4b
+ Signature: 22265ee70850324c45ce49a0599d86583a0b5bed82e4074fdc93f7d7fb8a1142f14783eb846be48a6d688988a4e203919ec0ccd3658fe742931a2f0ceaca728e
```