### PR TITLE
feat: publish event json from file

### DIFF
--- a/main.go
+++ b/main.go
@@ -20,7 +20,7 @@ Usage:
   noscl sign <event-json>
   noscl verify <event-json>
   noscl public
-  noscl publish [--reference=<id>...] [--profile=<id>...] <content>
+  noscl publish [--reference=<id>...] [--profile=<id>...] [--file=<file>] [<content>]
   noscl message [--reference=<id>...] <pubkey> <content>
   noscl metadata --name=<name> [--about=<about>] [--picture=<picture>] [--nip05=<nip05>] [--banner=<banner>] [--displayname=<displayname>] [--lud16=<lud16>] [--username=<username>] [--website=<website>]
   noscl profile [--verbose] [--json] <pubkey>
@@ -76,8 +76,8 @@ func main() {
 	switch {
 	case opts["home"].(bool):
 		home(opts, false)
-    case opts["inbox"].(bool):
-        home(opts, true)
+	case opts["inbox"].(bool):
+		home(opts, true)
 	case opts["setprivate"].(bool):
 		// TODO make this read STDIN and encrypt the key locally
 		setPrivateKey(opts)

--- a/publish.go
+++ b/publish.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"encoding/json"
 	"errors"
 	"log"
+	"os"
 	"time"
 
 	"github.com/docopt/docopt-go"
@@ -17,45 +19,66 @@ func publish(opts docopt.Opts) {
 
 	initNostr()
 
-	var tags nostr.Tags
+	var event nostr.Event
 
-	references, err := optSlice(opts, "--reference")
-	if err != nil {
-		return
-	}
-
-	for _, ref := range references {
-		tags = append(tags, nostr.Tag{"e", ref})
-	}
-
-	profiles, err := optSlice(opts, "--profile")
-	if err != nil {
-		return
-	}
-
-	for _, profile := range profiles {
-		tags = append(tags, nostr.Tag{"p", profile})
-	}
-
-	content := opts["<content>"].(string)
-	if content == "-" {
-		content, err = readContentStdin(4096)
+	if file, _ := opts.String("--file"); file != "" {
+		jsonb, err := os.ReadFile(file)
 		if err != nil {
-			log.Printf("Failed reading content from stdin: %s", err)
+			log.Printf("Failed reading content from file: %s", err)
+			return
+		}
+		if err := json.Unmarshal(jsonb, &event); err != nil {
+			log.Printf("Failed unmarshaling json from file: %s", err)
+			return
+		}
+	} else {
+		references, err := optSlice(opts, "--reference")
+		if err != nil {
+			return
+		}
+
+		var tags nostr.Tags
+		for _, ref := range references {
+			tags = append(tags, nostr.Tag{"e", ref})
+		}
+
+		profiles, err := optSlice(opts, "--profile")
+		if err != nil {
+			return
+		}
+
+		for _, profile := range profiles {
+			tags = append(tags, nostr.Tag{"p", profile})
+		}
+
+		content, _ := opts.String("<content>")
+		if content == "" {
+			log.Printf("Content must not be empty")
+			return
+		}
+		if content == "-" {
+			content, err = readContentStdin(4096)
+			if err != nil {
+				log.Printf("Failed reading content from stdin: %s", err)
+				return
+			}
+		}
+
+		event = nostr.Event{
+			CreatedAt: time.Now(),
+			Kind:      nostr.KindTextNote,
+			Tags:      tags,
+			Content:   content,
 		}
 	}
-	event, statuses, err := pool.PublishEvent(&nostr.Event{
-		CreatedAt: time.Now(),
-		Kind:      nostr.KindTextNote,
-		Tags:      tags,
-		Content:   content,
-	})
+
+	publishEvent, statuses, err := pool.PublishEvent(&event)
 	if err != nil {
 		log.Printf("Error publishing: %s.\n", err.Error())
 		return
 	}
 
-	printPublishStatus(event, statuses)
+	printPublishStatus(publishEvent, statuses)
 }
 
 func optSlice(opts docopt.Opts, key string) ([]string, error) {


### PR DESCRIPTION
Adds an optional `--file` flag to publish a json event from file. This can be useful as a dev tool when combined with `noscl sign`.